### PR TITLE
Add AWS Lambda steps to Github Action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,17 +1,14 @@
 name: .NET Core
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
-    
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build and run unit tests
+    name: Build and run unit tests on PR
     steps:
     - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598 # 2.0.0
     - name: Setup .NET Core

--- a/.github/workflows/deploy-to-lambda-on-merge.yml
+++ b/.github/workflows/deploy-to-lambda-on-merge.yml
@@ -1,0 +1,34 @@
+name: .NET Core
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Deploy to AWS Lambda on merge
+    steps:
+    - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598 # 2.0.0
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@b7821147f564527086410e8edd122d89b4b9602f # 1.4.0
+      with:
+        dotnet-version: 2.1.510
+    - name: Setup Nuget CLI
+      uses: NuGet/setup-nuget@255f46e14d51fbc603743e2aa2907954463fbeb9 # 1.0.2
+    - name: Install dotnet lambda tool
+      run: dotnet tool install --global Amazon.Lambda.Tools
+    - name: Publish with dotnet lambda
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        AWS_REGION: ${{ secrets.AWS_REGION }}
+      run: >-
+        dotnet lambda
+        deploy-function MyFunction
+        --project-location src/MyFunction
+        --function-role TestRole
+        --aws-access-key-id $AWS_ACCESS_KEY_ID
+        --aws-secret-key $AWS_SECRET_KEY
+        --region $AWS_REGION


### PR DESCRIPTION
After the merge to master, we want to deploy the function to AWS Lambda.
Since we're working on their build machines, we need to first install
the `dotnet lambda` tool, then publish the build using `dotnet lambda`.

For security, we pull the various configuration options from Github
secrets so they're not in source control.  To support this, we need to
add the following secrets:

 * `AWS_ACCESS_KEY_ID`
 * `AWS_SECRET_KEY`
 * `AWS_REGION`

Once these are set, this will publish changes to the lambda function on
merge to master.