### PR TITLE
Deploy Lambda function as a new version on merge

### DIFF
--- a/.github/workflows/deploy-to-lambda-on-merge.yml
+++ b/.github/workflows/deploy-to-lambda-on-merge.yml
@@ -32,3 +32,4 @@ jobs:
         --aws-access-key-id $AWS_ACCESS_KEY_ID
         --aws-secret-key $AWS_SECRET_KEY
         --region $AWS_REGION
+        --function-publish true


### PR DESCRIPTION
In order not to break any integrations with the Lambda function, we
should deploy the new build with an incremented version.  After the new
version is tested and verified, anyone calling the function can update
the ARN they are referencing.

Alternatively, we can set up an alias in Lambda, e.g. PROD, that points
to a specific version.  Instead of the callers updating the ARN they
reference, the alias can be changed to point to a new version.